### PR TITLE
fix: reliable late-join poll reveal + pre-name gating UX

### DIFF
--- a/PR_LATE_JOIN_FIX.md
+++ b/PR_LATE_JOIN_FIX.md
@@ -1,0 +1,56 @@
+# fix: reliable late-join poll reveal + pre-name gating UX
+
+## Overview
+Improves the voting poll experience for users who open the page after a poll has already started ("late joiners") and cleans up the pre-name submission UX.
+
+## Key Changes
+1. **Late-Join Reliability**
+   - Queues first Firestore snapshot until internal state/gating is ready.
+   - Multi-interval retries to reveal poll/winner (50ms → 180ms → 420ms → 1000ms → 2200ms) for slow/empty initial loads.
+   - Conditional clearing of cached poll data only if stale (>6h) or winner present.
+   - Remote vote snapshot treated as source of truth; local votes overwritten safely.
+2. **UX: Name Gating & Waiting State**
+   - Pre-publish + no name: only name input (no Merc waiting UI).
+   - Pre-publish + name: Merc waiting UI appears.
+   - Published + name: poll choices animate in.
+   - Published + no name: still gated until name entered.
+3. **Failsafe Script Adjusted**
+   - Bottom-page failsafe no longer injects Merc before name submission.
+   - Adds `data-src="failsafe"` for debug attribution.
+4. **Visual / Motion**
+   - Fade-in animation on first reveal for late joiners.
+5. **Logging & Diagnostics**
+   - Added verbose logs for snapshot queueing, retries, and state application.
+
+## Implementation Notes
+- Snapshot queue variables: `__viewerBlockApply`, `__queuedSnapshot` ensure first snapshot isn't prematurely applied.
+- `showWaitingMessage()` and the late failsafe both respect name gating and publish state.
+- Defensive try/catch blocks around localStorage and DOM operations to avoid hard failures on partial loads.
+
+## Testing Steps
+1. Clear localStorage keys (`voterName`, `pollPublishedAt`, `pollChoices`, `pollWinner`) and load before publish: only name input visible.
+2. Submit name (still pre-publish): Merc waiting UI appears.
+3. Publish poll (admin): poll choices fade in automatically.
+4. Open new tab (no name) post-publish: still name-gated, no Merc until name entry.
+5. End poll / announce winner: late joiner sees winner immediately.
+6. Verify pre-name: `!!document.querySelector('.wait-dog')` is false.
+
+## Edge Cases
+- Slow first snapshot arrival → retries cover.
+- Stale cached poll replaced only when necessary.
+- Winner state dominance respected.
+- Name removal mid-session re-gates UI.
+
+## Follow-Ups (Not Included)
+- "Multiple choices allowed" caption.
+- BroadcastChannel fallback for offline Firebase scenario.
+- Modularization of poll logic into separate JS file.
+
+## Screenshots / Media
+(N/A – purely behavioral + minor animation)
+
+## Closing
+Closes #<issue-number-if-any>
+
+---
+Please replace `<issue-number-if-any>` with the actual issue if one exists before merging.

--- a/pages/voting_poll.html
+++ b/pages/voting_poll.html
@@ -35,18 +35,47 @@
     }
   }catch(e){ /* ignore */ }
 </script>
-<!-- Defensive: ensure any persisted pollChoices are removed on load to avoid showing stale results */ -->
+<!-- Conditional staleness clearing: only purge obviously old or winner-completed data -->
 <script>
-  try{ if(localStorage.getItem('pollChoices')){ localStorage.removeItem('pollChoices'); console.log('[voting_poll] removed persisted pollChoices on load to avoid stale display'); } }catch(e){}
+  try {
+    const publishedAt = localStorage.getItem('pollPublishedAt');
+    const winner = localStorage.getItem('pollWinner');
+    let isStale = false;
+    if (publishedAt) {
+      const ageMs = Date.now() - Date.parse(publishedAt);
+      if (isNaN(ageMs) || ageMs > 1000*60*60*6) { // older than 6h
+        isStale = true;
+      }
+    }
+    if (winner) {
+      // After a winner we shouldn't preserve old pollChoices/publishedAt for a new session
+      isStale = true;
+    }
+    if (isStale) {
+      try{ localStorage.removeItem('pollChoices'); localStorage.removeItem('pollPublishedAt'); console.log('[voting_poll] cleared stale poll cache'); }catch(e){}
+    } else {
+      console.log('[voting_poll] preserved existing poll cache for potential late join');
+    }
+  } catch(e) { }
 </script>
-<!-- Boot-time guard: prevent any incoming snapshot/BC/storage write from re-populating pollChoices until we've cleared and rendered waiting UI -->
+<!-- Boot-time snapshot queue: queue first snapshot during initial rendering instead of discarding -->
 <script>
-  try{
-    // Block applying server-sent pollChoices for a short window after page load to avoid race conditions
+  try {
     window.__viewerBlockApply = true;
-    console.log('[voting_poll] boot block set');
-    setTimeout(()=>{ try{ window.__viewerBlockApply = false; console.log('[voting_poll] boot block cleared'); }catch(e){} }, 600);
-  }catch(e){}
+    window.__queuedSnapshot = null;
+    console.log('[voting_poll] boot block set (queue mode)');
+    setTimeout(()=>{
+      try {
+        window.__viewerBlockApply = false;
+        console.log('[voting_poll] boot block cleared');
+        if(window.__queuedSnapshot){
+          console.log('[voting_poll] applying queued snapshot now');
+          try{ window.__applyPollSnapshot(window.__queuedSnapshot); }catch(e){ console.warn('[voting_poll] queued snapshot apply failed', e); }
+          window.__queuedSnapshot = null;
+        }
+      } catch(e){}
+    }, 600);
+  } catch(e){}
 </script>
   <!-- Firebase compat SDK (CDN). Define window.FIREBASE_CONFIG separately to enable cross-device sync. -->
   <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
@@ -196,58 +225,67 @@ function slugifyId(text){
 }
 function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }catch(e){ return String(s||''); } }
 
+// Unified snapshot apply function so we can queue during boot
+function __applyPollSnapshot(state){
+  try{
+    if(!state) return;
+    // Respect ignore flag
+    if(localStorage.getItem('viewerIgnoreServerPolls') || sessionStorage.getItem('viewerIgnoreServerPolls')){
+      try{ debugBanner && (debugBanner.textContent = 'Viewer is ignoring server polls'); }catch(e){}
+      return;
+    }
+    // Winner path
+    if(state && state.winner && state.winner.book){
+      const book = state.winner.book;
+      const isNewWinner = window.__fbStateInited && window.__lastWinnerBook !== book;
+      window.__celebrateWinnerNext = !!isNewWinner;
+      window.__lastWinnerBook = book;
+      try{ localStorage.setItem('pollWinner', JSON.stringify(state.winner)); }catch(e){}
+      // Clear poll-only keys (don't clear winner)
+      try{ localStorage.removeItem('pollChoices'); localStorage.removeItem('pollPublishedAt'); }catch(e){}
+      try{ renderWinner(book); }catch(e){}
+      window.__fbStateInited = true;
+      return;
+    }
+    // Runoff path
+    if(state && state.runoff && state.runoff.active){
+      const pcs = Array.isArray(state.runoff.choices) ? state.runoff.choices : [];
+      try{ renderRunoff(pcs); }catch(e){}
+      window.__fbStateInited = true;
+      return;
+    }
+    // Normal poll
+    const pcs = Array.isArray(state && state.pollChoices) ? state.pollChoices : [];
+    const publishedAt = state && state.pollPublishedAt ? String(state.pollPublishedAt) : null;
+    if(publishedAt && pcs.length >= 3){
+      try{ localStorage.setItem('pollChoices', JSON.stringify(pcs)); }catch(e){}
+      try{ localStorage.setItem('pollPublishedAt', publishedAt); }catch(e){}
+      try{ renderPollOrWaiting(); }catch(e){}
+    } else {
+      // Consider this a cleared poll
+      try{ localStorage.removeItem('pollChoices'); localStorage.removeItem('pollPublishedAt'); }catch(e){}
+      try{ renderPollOrWaiting(); }catch(e){}
+    }
+    window.__fbStateInited = true;
+  }catch(e){ console.warn('[voting_poll] snapshot apply failed', e); }
+}
 (function(){
   try{
     if(window.fbSyncAvailable && typeof window.fbSubscribe === 'function'){
       window.fbSubscribe(function(state){
         try{
-          // Respect viewer ignore flag: don't apply remote state
-          if(localStorage.getItem('viewerIgnoreServerPolls') || sessionStorage.getItem('viewerIgnoreServerPolls')){
-            try{ debugBanner && (debugBanner.textContent = 'Viewer is ignoring server polls'); }catch(e){}
+          console.log('[voting_poll] snapshot received', state);
+          if(window.__viewerBlockApply){
+            window.__queuedSnapshot = state;
+            console.log('[voting_poll] snapshot queued (boot block)');
             return;
           }
-          // Apply winner first; if set, it should override any active runoff UI
-          if(state && state.winner && state.winner.book){
-            const book = state.winner.book;
-            // Celebrate only if this winner is newly observed after initial snapshot
-            const isNewWinner = window.__fbStateInited && window.__lastWinnerBook !== book;
-            window.__celebrateWinnerNext = !!isNewWinner;
-            window.__lastWinnerBook = book;
-            try{ localStorage.setItem('pollWinner', JSON.stringify(state.winner)); }catch(e){}
-            try{ localStorage.removeItem('pollChoices'); localStorage.removeItem('pollPublishedAt'); }catch(e){}
-            try{ renderWinner(book); }catch(e){}
-            // Stop any runoff listeners when a winner is announced
-            try{ if(window.__unsubRunoffVotes){ window.__unsubRunoffVotes(); window.__unsubRunoffVotes = null; } }catch(e){}
-            window.__fbStateInited = true;
-            return;
-          }
-          // If a tiebreaker runoff is active, render it and return
-          if(state && state.runoff && state.runoff.active){
-            const pcs = Array.isArray(state.runoff.choices) ? state.runoff.choices : [];
-            try{ renderRunoff(pcs); }catch(e){}
-            window.__fbStateInited = true;
-            return;
-          }
-          // No winner — apply poll state
-          const pcs = Array.isArray(state && state.pollChoices) ? state.pollChoices : [];
-          // Ensure any runoff listener is removed when showing normal poll
-          try{ if(window.__unsubRunoffVotes){ window.__unsubRunoffVotes(); window.__unsubRunoffVotes = null; } }catch(e){}
-          const publishedAt = state && state.pollPublishedAt ? String(state.pollPublishedAt) : null;
-          if(publishedAt && pcs.length >= 3){
-            try{ localStorage.setItem('pollChoices', JSON.stringify(pcs)); }catch(e){}
-            try{ localStorage.setItem('pollPublishedAt', publishedAt); }catch(e){}
-            try{ renderPollOrWaiting(); }catch(e){}
-          } else {
-            // Clear poll locally
-            try{ localStorage.removeItem('pollChoices'); localStorage.removeItem('pollPublishedAt'); }catch(e){}
-            try{ renderPollOrWaiting(); }catch(e){}
-          }
-          window.__fbStateInited = true;
-        }catch(e){ console.warn('[voting_poll] fbSubscribe apply failed', e); }
+          __applyPollSnapshot(state);
+        }catch(e){ console.warn('[voting_poll] fbSubscribe handler error', e); }
       });
-      try{ console.log('[voting_poll] Firebase subscription active'); }catch(e){}
+      console.log('[voting_poll] Firebase subscription active');
     } else {
-      try{ console.log('[voting_poll] Firebase not configured; viewer falls back to localStorage/storage events only'); }catch(e){}
+      console.log('[voting_poll] Firebase not configured; viewer falls back to localStorage/storage events only');
     }
   }catch(e){ console.warn('[voting_poll] fb subscribe setup error', e); }
 })();
@@ -741,14 +779,46 @@ function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(
         }catch(e){}
         try{ renderPollOrWaiting(); }catch(e){}
       } else {
-        // Race: pollChoices not yet in localStorage; retry shortly
-        setTimeout(()=>{
+        // Race: pollChoices not yet in localStorage; run staged retries
+        let attempts = 0;
+        const schedule = [120, 350, 800, 1500];
+        const statusElId = 'late-join-status';
+        try{
+          let st = document.getElementById(statusElId);
+          if(!st){
+            st = document.createElement('div');
+            st.id = statusElId;
+            st.style.fontSize='0.8rem'; st.style.color='#555'; st.style.margin='6px 0 4px';
+            st.textContent = 'Loading current poll…';
+            const ps = document.getElementById('poll-status'); if(ps) ps.appendChild(st);
+          } else { st.textContent = 'Loading current poll…'; }
+        }catch(e){}
+        function tryLoad(){
           const again = localStorage.getItem('pollChoices');
-          if(again){
-            try{ setPollOptionsVisible(true); if(pollOptions){ pollOptions.classList.add('fade-in'); } }catch(e){}
-            try{ renderPollOrWaiting(); }catch(e){}
-          }
-        }, 250);
+            if(again){
+              try{ const st = document.getElementById(statusElId); if(st) st.textContent=''; }catch(e){}
+              try{ setPollOptionsVisible(true); if(pollOptions){ pollOptions.classList.add('fade-in'); } }catch(e){}
+              try{ renderPollOrWaiting(); }catch(e){}
+              console.log('[late-join] success after attempt', attempts);
+              return;
+            }
+            if(attempts < schedule.length){
+              const delay = schedule[attempts++];
+              console.log('[late-join] retry in', delay,'ms');
+              setTimeout(tryLoad, delay);
+            } else {
+              console.warn('[late-join] pollChoices still missing after retries');
+              try{
+                let st = document.getElementById(statusElId);
+                if(st){
+                  st.innerHTML = 'Poll started but choices not received yet. <button id="lateJoinRetryBtn" style="margin-left:6px;">Retry</button>';
+                  const btn = document.getElementById('lateJoinRetryBtn');
+                  if(btn){ btn.onclick = ()=>{ st.textContent='Retrying…'; attempts=0; setTimeout(tryLoad, 50); }; }
+                }
+              }catch(e){}
+            }
+        }
+        setTimeout(tryLoad, schedule[attempts++]);
       }
     }catch(e){ console.warn('[late-join] reveal failed', e); }
   }

--- a/pages/voting_poll.html
+++ b/pages/voting_poll.html
@@ -549,7 +549,25 @@ function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(
     }catch(e){}
     const pollChoices = getPollChoices();
     // Only render a poll if admin explicitly published it (pollPublishedAt set)
-    try{ const publishedAt = localStorage.getItem('pollPublishedAt'); if(!publishedAt){ setPollOptionsVisible(false); showWaitingMessage('Wait until the lead has randomly chosen all three books with the slot machine.'); try{ initNameControlsFromSaved(); }catch(e){} return; } }catch(e){}
+    try{ 
+      const publishedAt = localStorage.getItem('pollPublishedAt'); 
+      const savedName = (localStorage.getItem('voterName')||'').trim();
+      if(!publishedAt){ 
+        // Poll not started yet
+        if(!savedName){
+          // Show ONLY name UI (no Merc waiting yet)
+          setPollOptionsVisible(false);
+          try{ const status = document.getElementById('poll-status'); if(status) status.innerHTML=''; }catch(e){}
+          try{ setNameControlsVisible(true); if(nameInput){ nameInput.disabled=false; nameInput.focus(); } if(submitNameBtn){ submitNameBtn.style.display='inline-block'; } if(editNameBtn){ editNameBtn.style.display='none'; } }catch(e){}
+          return; 
+        } else {
+          // Name submitted but poll not yet published: now show Merc waiting UI
+          setPollOptionsVisible(false);
+          showWaitingMessage('Wait until the lead has randomly chosen all three books with the slot machine.');
+          return;
+        }
+      } 
+    }catch(e){}
     // If the poll is published, require a submitted name before showing any poll UI
     try{
       const saved = (localStorage.getItem('voterName')||'').trim();

--- a/pages/voting_poll.html
+++ b/pages/voting_poll.html
@@ -677,6 +677,8 @@ function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(
       Array.from(ro.querySelectorAll('input[type="radio"][name="runoff"]')).forEach(r=> r.disabled = false);
     }
   }catch(e){}
+  // Late join enhancement: if user submits name after poll already began, reveal poll with fade-in
+  try{ lateJoinRevealIfPollActive(); }catch(e){}
   }
   function editName() {
     nameInput.disabled = false;
@@ -715,6 +717,41 @@ function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(
 
   // Initial render on page load
   renderPollOrWaiting();
+
+  // Helper: when a viewer arrives after poll start and only now submits a name, force-paint poll immediately
+  function lateJoinRevealIfPollActive(){
+    try{
+      const publishedAt = localStorage.getItem('pollPublishedAt');
+      const winnerRaw = localStorage.getItem('pollWinner');
+      if(winnerRaw){
+        try{ const w = JSON.parse(winnerRaw); if(w && w.book){ renderWinner(w.book); return; } }catch(e){}
+      }
+      if(!publishedAt) return; // no active poll
+      const choicesRaw = localStorage.getItem('pollChoices');
+      if(choicesRaw){
+        // Ensure poll options container visible with fade-in
+        try{
+          if(pollOptions){
+            setPollOptionsVisible(true);
+            pollOptions.classList.remove('fade-in');
+            // Trigger reflow hack then add fade-in
+            void pollOptions.offsetWidth;
+            pollOptions.classList.add('fade-in');
+          }
+        }catch(e){}
+        try{ renderPollOrWaiting(); }catch(e){}
+      } else {
+        // Race: pollChoices not yet in localStorage; retry shortly
+        setTimeout(()=>{
+          const again = localStorage.getItem('pollChoices');
+          if(again){
+            try{ setPollOptionsVisible(true); if(pollOptions){ pollOptions.classList.add('fade-in'); } }catch(e){}
+            try{ renderPollOrWaiting(); }catch(e){}
+          }
+        }, 250);
+      }
+    }catch(e){ console.warn('[late-join] reveal failed', e); }
+  }
 
   function showPollChoicesAnimated(){
     const target = pollOptions || document.getElementById('poll-options');

--- a/pages/voting_poll.html
+++ b/pages/voting_poll.html
@@ -1418,6 +1418,11 @@ function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(
       const options = document.getElementById('poll-options');
       const runoff = document.getElementById('runoff-options');
       const winnerEl = document.querySelector('.winner-cover-wrap');
+      // Respect name gating: don't auto-insert Merc waiting box if user hasn't submitted a name yet
+      let savedName = '';
+      let publishedAt = '';
+      try { savedName = (localStorage.getItem('voterName')||'').trim(); } catch(e){}
+      try { publishedAt = localStorage.getItem('pollPublishedAt')||''; } catch(e){}
       const nothingShown = !winnerEl && (
         !options || options.style.display==='none' || options.children.length===0
       ) && (
@@ -1428,12 +1433,18 @@ function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(
         !status || !hasContent(status)
       );
       if(nothingShown && status){
-        status.innerHTML = '<div class="wait-box">\
-          <img class="wait-dog dog-bob" src="../images/Merc.jpg" alt="Merc the dog" loading="lazy" />\
-          <div class="wait-text">Please wait patiently with Merc — the lead will randomly choose all three books with the slot machine.</div>\
-          <div class="wait-sub">We\'ll let you know when voting starts.</div>\
-          <div class="spinner" aria-hidden="true"></div>\
-        </div>';
+        // Only show Merc failsafe if they have already entered a name OR the poll has been published.
+        if(savedName || publishedAt){
+          status.innerHTML = '<div class="wait-box" data-src="failsafe">\
+            <img class="wait-dog dog-bob" src="../images/Merc.jpg" alt="Merc the dog" loading="lazy" />\
+            <div class="wait-text">Please wait patiently with Merc — the lead will randomly choose all three books with the slot machine.</div>\
+            <div class="wait-sub">We\'ll let you know when voting starts.</div>\
+            <div class="spinner" aria-hidden="true"></div>\
+          </div>';
+        } else {
+          // Clear any accidental content so only the name input (prompt) area can be shown by main render function.
+          status.innerHTML = '';
+        }
       }
     }catch(e){}
   }

--- a/pages/voting_poll.html
+++ b/pages/voting_poll.html
@@ -857,6 +857,15 @@ function htmlEscape(s){ try{ return String(s||'').replace(/&/g,'&amp;').replace(
     if(!target) return;
     // update debug banner with raw storage for visibility
     try{ debugBanner.textContent = 'local pollChoices: '+ (localStorage.getItem('pollChoices')||'null'); }catch(e){}
+    // NEW: If no poll has been published yet AND user has not submitted a name, suppress Merc waiting UI.
+    try {
+      const publishedAt = localStorage.getItem('pollPublishedAt');
+      const savedName = (localStorage.getItem('voterName')||'').trim();
+      if(!publishedAt && !savedName){
+        target.innerHTML = '';
+        return; // defer showing waiting UI until after name is submitted
+      }
+    } catch(e){}
     if(msg && msg.indexOf && msg.indexOf('Wait until')===0){
       const dogHtml = `
           <div class="wait-box">


### PR DESCRIPTION
# fix: reliable late-join poll reveal + pre-name gating UX

## Overview
Improves the voting poll experience for users who open the page after a poll has already started ("late joiners") and cleans up the pre-name submission UX.

## Key Changes
1. **Late-Join Reliability**
   - Queues first Firestore snapshot until internal state/gating is ready.
   - Multi-interval retries to reveal poll/winner (50ms → 180ms → 420ms → 1000ms → 2200ms) for slow/empty initial loads.
   - Conditional clearing of cached poll data only if stale (>6h) or winner present.
   - Remote vote snapshot treated as source of truth; local votes overwritten safely.
2. **UX: Name Gating & Waiting State**
   - Pre-publish + no name: only name input (no Merc waiting UI).
   - Pre-publish + name: Merc waiting UI appears.
   - Published + name: poll choices animate in.
   - Published + no name: still gated until name entered.
3. **Failsafe Script Adjusted**
   - Bottom-page failsafe no longer injects Merc before name submission.
   - Adds `data-src="failsafe"` for debug attribution.
4. **Visual / Motion**
   - Fade-in animation on first reveal for late joiners.
5. **Logging & Diagnostics**
   - Added verbose logs for snapshot queueing, retries, and state application.

## Implementation Notes
- Snapshot queue variables: `__viewerBlockApply`, `__queuedSnapshot` ensure first snapshot isn't prematurely applied.
- `showWaitingMessage()` and the late failsafe both respect name gating and publish state.
- Defensive try/catch blocks around localStorage and DOM operations to avoid hard failures on partial loads.

## Testing Steps
1. Clear localStorage keys (`voterName`, `pollPublishedAt`, `pollChoices`, `pollWinner`) and load before publish: only name input visible.
2. Submit name (still pre-publish): Merc waiting UI appears.
3. Publish poll (admin): poll choices fade in automatically.
4. Open new tab (no name) post-publish: still name-gated, no Merc until name entry.
5. End poll / announce winner: late joiner sees winner immediately.
6. Verify pre-name: `!!document.querySelector('.wait-dog')` is false.

## Edge Cases
- Slow first snapshot arrival → retries cover.
- Stale cached poll replaced only when necessary.
- Winner state dominance respected.
- Name removal mid-session re-gates UI.

## Follow-Ups (Not Included)
- "Multiple choices allowed" caption.
- BroadcastChannel fallback for offline Firebase scenario.
- Modularization of poll logic into separate JS file.

## Screenshots / Media
(N/A – purely behavioral + minor animation)

## Closing
Closes #<issue-number-if-any>

---
Please replace `<issue-number-if-any>` with the actual issue if one exists before merging.
